### PR TITLE
Update ViroReact to v2.13.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react-native"]
+  "presets": ["module:metro-react-native-babel-preset"]
 }

--- a/App.js
+++ b/App.js
@@ -19,7 +19,7 @@ import config from './config';
 import localStyles from './localStyles';
 
 // Device Heading
-import ReactNativeHeading from "@zsajjad/react-native-heading";
+import ReactNativeHeading from "react-native-heading";
 
 //
 // ─── LOGIN FORM ─────────────────────────────────────────────────────────────────

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/android/app/.classpath
+++ b/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/android/app/.project
+++ b/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,13 +94,14 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+    flavorDimensions "platform"
 
     defaultConfig {
         applicationId "com.virosample"
         minSdkVersion 23
-        targetSdkVersion 25
+        targetSdkVersion 28
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
@@ -153,33 +154,22 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-firebase')
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.facebook.react:react-native:+'
-    compile project(':arcore_client') // remove this if AR not required
-    compile project(':gvr_common')
-    compile project(path: ':viro_renderer')
-    compile project(path: ':react_viro')
-    compile 'com.google.android.exoplayer:exoplayer:2.7.1'
-    compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
-    compile 'com.amazonaws:aws-android-sdk-core:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-ddb:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-ddb-mapper:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-cognito:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-cognitoidentityprovider:2.2.+'
-    compile project(':arcore_client') // remove this if AR not required
-    compile project(':gvr_common')
-    compile project(path: ':viro_renderer')
-    compile project(path: ':react_viro')
-    compile 'com.google.android.exoplayer:exoplayer:r2.2.0'
-    compile 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
-    compile 'com.amazonaws:aws-android-sdk-core:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-ddb:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-ddb-mapper:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-cognito:2.2.+'
-    compile 'com.amazonaws:aws-android-sdk-cognitoidentityprovider:2.2.+'
-    compile project(':react-native-heading')
+    implementation project(':react-native-firebase')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation project(':arcore_client') // remove this if AR not required
+    implementation project(':gvr_common')
+    implementation project(path: ':viro_renderer')
+    implementation project(path: ':react_viro')
+    implementation 'com.google.android.exoplayer:exoplayer:2.7.1'
+    implementation 'com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-7'
+    implementation 'com.amazonaws:aws-android-sdk-core:2.7.7'
+    implementation 'com.amazonaws:aws-android-sdk-ddb:2.7.7'
+    implementation 'com.amazonaws:aws-android-sdk-ddb-mapper:2.7.7'
+    implementation 'com.amazonaws:aws-android-sdk-cognito:2.7.7'
+    implementation 'com.amazonaws:aws-android-sdk-cognitoidentityprovider:2.7.7'
+    implementation project(':react-native-heading')
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,15 +122,15 @@ android {
             resValue 'string', 'app_name', 'ViroSample-ar'
             buildConfigField 'String', 'VR_PLATFORM', '"GVR"'
         }
-        gvr {
-            resValue 'string', 'app_name', 'ViroSample-gvr'
-            buildConfigField 'String', 'VR_PLATFORM', '"GVR"'
-        }
-        ovr {
-            resValue 'string', 'app_name', 'ViroSample-ovr'
-            applicationIdSuffix '.ovr'
-            buildConfigField 'String', 'VR_PLATFORM', '"OVR_MOBILE"'
-        }
+        // gvr {
+        //     resValue 'string', 'app_name', 'ViroSample-gvr'
+        //     buildConfigField 'String', 'VR_PLATFORM', '"GVR"'
+        // }
+        // ovr {
+        //     resValue 'string', 'app_name', 'ViroSample-ovr'
+        //     applicationIdSuffix '.ovr'
+        //     buildConfigField 'String', 'VR_PLATFORM', '"OVR_MOBILE"'
+        // }
     }
     buildTypes {
         release {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/android/app/src/main/java/com/virosample/MainActivity.java
+++ b/android/app/src/main/java/com/virosample/MainActivity.java
@@ -1,7 +1,11 @@
 package com.virosample;
 
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.shell.MainReactPackage;
 import com.joshblour.reactnativeheading.ReactNativeHeadingPackage;
+import java.util.Arrays;
+import java.util.List;
 
 public class MainActivity extends ReactActivity {
 
@@ -14,7 +18,7 @@ public class MainActivity extends ReactActivity {
         return "ViroSample";
     }
 
-    @Override
+    // @Override
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -27,5 +27,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        google()
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,4 +9,4 @@ project(':gvr_common').projectDir = new File('../node_modules/react-viro/android
 project(':viro_renderer').projectDir = new File('../node_modules/react-viro/android/viro_renderer')
 project(':react_viro').projectDir = new File('../node_modules/react-viro/android/react_viro')
 include ':react-native-heading'
-project(':react-native-heading').projectDir = new File(rootProject.projectDir, '../node_modules/@zsajjad/react-native-heading/android')
+project(':react-native-heading').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-heading/android')

--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,14 @@
 import { AppRegistry } from 'react-native';
 import App from './App.js';
 
+// These requires fix a weird build error. For more details,
+// visit https://github.com/facebook/react-native/issues/20902#issuecomment-447593887
+global.Symbol = require('core-js/es6/symbol');
+require('core-js/fn/symbol/iterator');
+require('core-js/fn/map');
+require('core-js/fn/set');
+require('core-js/fn/array/find');
+
 AppRegistry.registerComponent('ViroSample', () => App);
 
 // The below line is necessary for use with the TestBed App

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,6 +1,14 @@
 import { AppRegistry } from 'react-native';
 import App from './App.js';
 
+// These requires fix a weird build error. For more details,
+// visit https://github.com/facebook/react-native/issues/20902#issuecomment-447593887
+global.Symbol = require('core-js/es6/symbol');
+require('core-js/fn/symbol/iterator');
+require('core-js/fn/map');
+require('core-js/fn/set');
+require('core-js/fn/array/find');
+
 AppRegistry.registerComponent('ViroSample', () => App);
 
 // The below line is necessary for use with the TestBed App

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 import { AppRegistry } from 'react-native';
 import App from './App.js';
 
+// These requires fix a weird build error. For more details,
+// visit https://github.com/facebook/react-native/issues/20902#issuecomment-447593887
+global.Symbol = require('core-js/es6/symbol');
+require('core-js/fn/symbol/iterator');
+require('core-js/fn/map');
+require('core-js/fn/set');
+require('core-js/fn/array/find');
+
 AppRegistry.registerComponent('ViroSample', () => App);
 
 // The below line is necessary for use with the TestBed App

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { getDefaultConfig } = require("metro-config");
+
+module.exports = (async () => {
+  const {
+    resolver: { assetExts }
+  } = await getDefaultConfig();
+
+  return {
+    resolver: {
+      assetExts: [...assetExts, "obj", "mtl", "JPG", "vrx", "hdr", "gltf", "glb", "bin", "arobject", "gif"]
+    }
+  };
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4088,7 +4088,6 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"inherits": "~2.0.0"
 					}
@@ -4110,8 +4109,7 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -4125,8 +4123,7 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
@@ -4142,18 +4139,15 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.x.x"
 					}
@@ -4216,8 +4210,7 @@
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
@@ -4326,7 +4319,6 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"boom": "2.x.x",
 						"cryptiles": "2.x.x",
@@ -4368,7 +4360,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4380,8 +4371,7 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -4568,8 +4558,7 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -4602,7 +4591,6 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -4651,8 +4639,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"semver": {
 					"version": "5.3.0",
@@ -4672,7 +4659,6 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"hoek": "2.x.x"
 					}
@@ -4703,7 +4689,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4713,7 +4698,6 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -4738,7 +4722,6 @@
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"block-stream": "*",
 						"fstream": "^1.0.2",
@@ -4788,8 +4771,7 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"uuid": {
 					"version": "3.0.1",
@@ -13073,6 +13055,11 @@
 					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
 				}
 			}
+		},
+		"react-native-heading": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/react-native-heading/-/react-native-heading-1.1.1.tgz",
+			"integrity": "sha1-pkJrtiffdLHzEvhm0QPe/IX9o1c="
 		},
 		"react-native-maps": {
 			"version": "0.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,310 +8,330 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/core": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.46.tgz",
-			"integrity": "sha512-lCDbBSAhNAt+nL98xbgWmuhgrIxKvbvFHf73zlNCuXCHJkdlo7qzTofYK0ZWb+OVce8fQ17fC7DwTIhAwowzMw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+			"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/generator": "7.0.0-beta.46",
-				"@babel/helpers": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helpers": "^7.2.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/template": "^7.2.2",
+				"@babel/traverse": "^7.2.2",
+				"@babel/types": "^7.2.2",
 				"convert-source-map": "^1.1.0",
-				"debug": "^3.1.0",
-				"json5": "^0.5.0",
-				"lodash": "^4.2.0",
-				"micromatch": "^2.3.11",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.10",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-					"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.46"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-					"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
+				"@babel/parser": {
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+					"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
 				},
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 				},
 				"resolve": {
-					"version": "1.7.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+					"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
 					"requires": {
-						"path-parse": "^1.0.5"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
+						"path-parse": "^1.0.6"
 					}
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
-			"integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+			"integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46",
+				"@babel/types": "^7.2.2",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
+				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 				}
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.46.tgz",
-			"integrity": "sha512-ej5W347ghJF1p2TM3VcEyds1+o1uy1apaQcHrYFJPus2xCgn5KkHPkBGf+6euLfFaQDtB+eWPVKjiZx/hpYXvA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.46.tgz",
-			"integrity": "sha512-ZCQ62KqFC5R3NPe5ug9pVqIHYJNup8UdEbE4IXw+s7zr4D/7AsKSt3pXA+FbML5AnQXeCSOuUWioggGmKuDV5g==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.46.tgz",
-			"integrity": "sha512-4xakEEfimusXNgpSY6rP7robwRcnv1E8OxjkYSfsZCYsomFwN7RXU5S29vGWzxE37Yua4yTFqBwId9lwF84Hzw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
+			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46",
+				"@babel/types": "^7.0.0",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.46.tgz",
-			"integrity": "sha512-7nhBu/MBlpvZLQsmw/C7VxN14wph+yp+1yxzPEd2oTsHg3oA73tHyguQ6wbtkw+9f1AZtP7ZJCLQ+nGLprF4Fw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
 			"requires": {
-				"@babel/helper-hoist-variables": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.2.3.tgz",
+			"integrity": "sha512-xO/3Gn+2C7/eOUeb0VRnSP1+yvWHNxlpAot1eMhtoKDCN7POsyQP5excuT5UsV5daHxMWBeIIOeI5cmB8vMRgQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.2.3"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.46.tgz",
-			"integrity": "sha512-rhi59ZVj+bhrgxqLi9VQmQOadcK9rLCArY8zqyjPNjDIsCurCwtQztRWhlz6CwBEhE9FO/KbSa9OFQm7Kobk+w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.46.tgz",
-			"integrity": "sha512-SW1OUmx2fC2SqL7+vF1N72FITbPuEWGdr/Gm7I3Vqs8p8T1dfGwB9YFsD+tTpfagKXVMiCCuQ06+G0FB8uxg6Q==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
 			"requires": {
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
-			"integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
-			"integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.46.tgz",
-			"integrity": "sha512-9xDHLfaVA445mcHU2OEPwEddiyS0Zxao2WObFR2L/SK5MNOPj2VqVCvivYrO2OpzhnLLCTbOfXRmrwrc9WYN6Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.46.tgz",
-			"integrity": "sha512-Xb5iVUHXY8yz4pgGBvtuS1kxZH1oUYcxTcbIW8NFRvgpeH3Zcv4me02bbixsk7nhn8ttE79Lr1g4vrem4k5Z3Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.46.tgz",
-			"integrity": "sha512-xjgpwrqHiKCZgAcqsNIpZ9kOCC5Ty/VYN1H07v21HbAf/dl0/HeUA0taz3EFv6/7lRgS3qThawTSG0POJQX9vQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.46.tgz",
-			"integrity": "sha512-IckoWSub3PHNvkWcUEWfKBe8pFUdMhsZMFDcaovcLb+gfxL/zZhQYwedKKKwbzVGIk9k44yjeMQ/OJd4yt4FGQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
+			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
 			"requires": {
-				"@babel/helper-module-imports": "7.0.0-beta.46",
-				"@babel/helper-simple-access": "7.0.0-beta.46",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.2.2",
+				"@babel/types": "^7.2.2",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.46.tgz",
-			"integrity": "sha512-PVd7/PGxi82pEKyuDcEpMmlenMLhJCII3lIK4MhXGWrT/6cNMpY6ob5rWOarpXgZjy+JNI5uLPOce28bqq0Wtw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.46.tgz",
-			"integrity": "sha512-eRTFH+/1rqDfzx+Z//CYk4TNwhfPQpM/TCs4CmHu2DwCPrqFnKUZLI1KgStfLf//c8FdOqx/U9EPec7s8CbUIA=="
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+		},
+		"@babel/helper-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"requires": {
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
+			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.46.tgz",
-			"integrity": "sha512-YrqQ98z8AMZx8f2PGJ4YV1MkXtj+qbwbFV7MOLTiavGSFY7UrN4uQfhKEJ/4GUf4QZdTr5NEmRt0AJrWno8y8w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-				"@babel/helper-wrap-function": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.46.tgz",
-			"integrity": "sha512-FSpK3QKzb58oMEccanHzg1djsYHhGARl08i8BQGBoOyHS6Df+4/8bsQiTnc59Dz5sJoZdb67nKKFjgMsMYi6Kg==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
+			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "7.0.0-beta.46",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.2.3",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.46.tgz",
-			"integrity": "sha512-1OEjV/Qnl4u8Dg+jQIYf1TgnfdrYIrdrF7yZwp9mSgsVX2PCyLe7JNTqZ/5v/5RzlF6S+GTe9agkj+EFFTcZUw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
 			"requires": {
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
-			"integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.46.tgz",
-			"integrity": "sha512-W87M4bP6veTKK66OjzV/rU47tjsWmKj9J0J5BDmxq5BIJB1M13ouQ2FAURa4jGHwjPFWN3D5njBrsrifSOHzbQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.2.0"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.46.tgz",
-			"integrity": "sha512-mbpH9pM3pJzo/tBr75U+zva3pqpyivogt1aofgEoD7bWFAYSuqOudRuz+m4XP6VPxxLoxcA4SFPGkuLRt9+7nQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
+			"integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
 			"requires": {
-				"@babel/template": "7.0.0-beta.46",
-				"@babel/traverse": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46"
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.2.0"
 			}
 		},
 		"@babel/highlight": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -322,7 +342,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -331,7 +350,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -341,14 +359,12 @@
 				"js-tokens": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-					"dev": true
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -358,452 +374,593 @@
 		"@babel/parser": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-			"integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
-			"dev": true
+			"integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
 		},
 		"@babel/plugin-external-helpers": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.46.tgz",
-			"integrity": "sha512-ajlMWy4VZ/aOUl7Z5UPy8AKtm1AHu6oEw6WiZCspjSYU6PlwiwuU3ofqcPXOaSjK+3SBFT6zViq1iF8ZxzYYxg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
+			"integrity": "sha512-QFmtcCShFkyAsNtdCM3lJPmRe1iB+vPZymlB4LnDIKEBj2yKQLQKtoxXxJ8ePT5fwMl4QGg303p4mB0UsSI2/g==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.46.tgz",
-			"integrity": "sha512-kWp3bKibdSeSEvEQWcEcs345KPQYT39uM2edFS78NH3Gu6O9mBcnXh5E2BJ1sbE+jJ6jYPOZz4BK/LR7BiF0jA==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.3.tgz",
+			"integrity": "sha512-FVuQngLoN2iDrpW7LmhPZ2sO4DJxf35FOcwidwB9Ru9tMvI5URthnkVHuG14IStV+TzkMTyLMoOUlSTtrdVwqw==",
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/helper-replace-supers": "7.0.0-beta.46",
-				"@babel/plugin-syntax-class-properties": "7.0.0-beta.46"
+				"@babel/helper-create-class-features-plugin": "^7.2.3",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-export-default-from": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.2.0.tgz",
+			"integrity": "sha512-NVfNe7F6nsasG1FnvcFxh2FN0l04ZNe75qTOAVOILWPam0tw9a63RtT/Dab8dPjedZa4fTQaQ83yMMywF9OSug==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-export-default-from": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.2.0.tgz",
+			"integrity": "sha512-QXj/YjFuFJd68oDvoc1e8aqLr2wz7Kofzvp6Ekd/o7MWZl+nZ0/cpStxND+hlZ7DpRWAp7OmuyT2areZ2V3YUA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.46.tgz",
-			"integrity": "sha512-viGuWOgFT/Tbnn3sYi3g9iJcC3ql7bSjxDs+d+GFgyf3eV2qNIKO/6I+PJAD35fGqDGGBrQhlA6HvW0FzQVtoA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz",
+			"integrity": "sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.2.0"
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.46.tgz",
-			"integrity": "sha512-NwtgTQ+I8B2eo5h1mZF64nloLaGQuPM4M/c/swvyvqHoWLissHhm94rOE2Ghte8WMgQ/Nw3bqJd59kpbckqmdQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
+			"integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.46.tgz",
-			"integrity": "sha512-D4ek6tZa80NgaTSprPOVxj8vxjChh6UCWgCT/ZvCwAa6CBe3iqUCuOwZQLjU41aDdeuR7C02wxl3rcb25wCRLA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-export-default-from": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.2.0.tgz",
+			"integrity": "sha512-c7nqUnNST97BWPtoe+Ssi+fJukc9P9/JMZ71IOMNQWza2E+Psrd46N6AEvtw6pqK+gt7ChjXyrw4SPDO79f3Lw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-flow": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.46.tgz",
-			"integrity": "sha512-HFChD9R2w+8+Jt5539SVaKKSYuMvbCgYG7LmuISycaJW16aS6fNS6V8jr8U/HKJk3bhIG5SkATBYedy5zGR+sg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
+			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.46.tgz",
-			"integrity": "sha512-aYN4vmO4nMux1W36F6/YP2ugNQ0cilrs1eU4jClLrlIouxqd9hqBloWtlGmGlyDxIRV5kzr+UWwridLDb+cN5g==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz",
+			"integrity": "sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.46.tgz",
-			"integrity": "sha512-MMv6WG69jmcSLXdUeHvoev5RkuP/QuJZwCB4jXp2gtss//avs4Sns+t0VpGKTf9umhvRq44HFO6PVjVG85F+/Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+			"integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz",
+			"integrity": "sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.46.tgz",
-			"integrity": "sha512-GgeFCCMHXWRkPDXWKin76qiZh+DAYdQShmk8SmzDj6IAgPHyNqkxHN/8gsmNe5/7IWFFOKUuM9TNU7fgY7z7Gg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
+			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.46.tgz",
-			"integrity": "sha512-7OwS0ObI6nLacEKP1HCdnoIQnHBqOV6IgtKGiPO+Nj03OnZ1Yo2aeK9sfOtwL43aNztnKqFVt2L5PfZg4VGidA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
+			"integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.46.tgz",
-			"integrity": "sha512-EDp/qQAURfrX6hNM+VrLSSA+cGiwDeZL0ZTTt6a7PNSFABCw4qwKJHx3Q7me1oV7q3U/GJwPS4Aym2QTDmNGvg==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
+			"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-				"@babel/helper-define-map": "7.0.0-beta.46",
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/helper-optimise-call-expression": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/helper-replace-supers": "7.0.0-beta.46",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
 				"globals": {
-					"version": "11.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
 				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.46.tgz",
-			"integrity": "sha512-0ne9TL53fXH+cBI591R1JSpPhu0d2Wd9dbD8jLCJFV4tlMfqQ+Rcm65RhWWqjEBZfGv2+FuOnwB4HJRHakdW+Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.46.tgz",
-			"integrity": "sha512-l9x0+T29Njwp6smLbTIU2HG2s4ROd9DAIQcfciEfpjAqscXEst0M4X9+UvjQsuaOgPFmQTdAn9xOwNFXnRP7Tg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
+			"integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.46.tgz",
-			"integrity": "sha512-acomgoNW/fwWSmBlhH22C9Eyl1Y/vADBSqzyIRWJGpm4frLhd49QQgKXbRGRHUDxyifXuZDF9+3pRhEmi7/HXA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.46.tgz",
-			"integrity": "sha512-ZyMayIXoDPsYYa8FVypQpcxeHX65l6lQ/nA4DRTSJUVvoQDytfNlH3Y3yQhGwyrr2APsCpq4MGmUAp+Id8KWeA==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.3.tgz",
+			"integrity": "sha512-xnt7UIk9GYZRitqCnsVMjQK1O2eKZwFB3CvvHjf5SGx6K6vr/MScCKQDnf1DxRaj501e3pXjti+inbSXX2ZUoQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/plugin-syntax-flow": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.46.tgz",
-			"integrity": "sha512-a1gpwuO26szyz5K2FrRrI5nUDgvkaJfZ7GeDtFAH8XyrK/pNdtpW/7DFCf1PdQc6SbEMM/1QXsH7Y2YRkWoTeA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
+			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.46.tgz",
-			"integrity": "sha512-XyxSW1jm7WKOoPYHUJA0mbOkDFdlHzGR4DzlWAEwXrzEI5ep0ZP1AttAbVkxsF63XG8p2t9VtKlgbyBq4Tyr7A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
+			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
 			"requires": {
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.46.tgz",
-			"integrity": "sha512-Uuo7pRsBkrLrDg6XpOAMfwhKw56SB5qVBniUVM04uf8wf92S2Z5tSPNNfn1iTgphuckAO9vg86l2XJ0Y/QD4YQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.46.tgz",
-			"integrity": "sha512-3wLCWVkEhhQiVqqml4y9G6GJT6WA/mkxQ6TRy+4I46z00WWbEDENJcRTS14oNKzeRIo4yJylbVB1wUCW7HuJ9A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
+			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
 			"requires": {
-				"@babel/helper-module-transforms": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/helper-simple-access": "7.0.0-beta.46"
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-object-assign": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.0.0-beta.46.tgz",
-			"integrity": "sha512-ffsPVSLMz6MaQ5YqbrjUnYz6votox8jOhTgO3FYvWtaUiCUDE9KtmGvAS7dSAzpPELgfm1mstinkBupEzmXYeA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz",
+			"integrity": "sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.46.tgz",
-			"integrity": "sha512-RnkdYrayTlQ0VFoyIjvY/cCp/1lJJkYE2lFcRNg6+Skd3g41PnocsHhQ5NUQjMNogL+RnNan3S/2S/i7S4zm+Q==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
+			"integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
 			"requires": {
-				"@babel/helper-call-delegate": "7.0.0-beta.46",
-				"@babel/helper-get-function-arity": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0-beta.46.tgz",
-			"integrity": "sha512-/a7wwzNrYqReyuOM8rBB9iAOLaubvGHM9w3eUeput/DnEq/V+dJuBgktpF6mw/MQjwjna1B/3BbWsn1PaBw8bw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.46.tgz",
-			"integrity": "sha512-b8VtHVQub3h7lXG1ShaCKgGJdra7fRlUK6hx1eCcIWAPYnJMz4soLMSPiXmyjDA5L0CbYmyTkceU1GjbeJmaaw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.2.0.tgz",
+			"integrity": "sha512-h/fZRel5wAfCqcKgq3OhbmYaReo7KkoJBpt8XnvpS7wqaNMqtw5xhxutzcm35iMUWucfAdT/nvGTsWln0JTg2Q==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.46"
+				"@babel/helper-builder-react-jsx": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0-beta.46.tgz",
-			"integrity": "sha512-vSSghGn+ER6d5gBtNnTZAxPxBSs1ngyyVlHse/geHSv7YnzmrCOUrtVl+t4M2/EO3CW2m8nkMfpnMW5FCmg+Zw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"@babel/plugin-syntax-jsx": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.46.tgz",
-			"integrity": "sha512-P6d8ckSjKlbr/1SL1NBO6ieFxSebTiRWd2R8/styUIizJWQlEB0ITQ7l8vv3jXGjJ0mh7lxBTegXejRkTGKKgw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
 			"requires": {
-				"regenerator-transform": "^0.12.3"
+				"regenerator-transform": "^0.13.3"
 			},
 			"dependencies": {
 				"regenerator-transform": {
-					"version": "0.12.3",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
-					"integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+					"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
 					"requires": {
 						"private": "^0.1.6"
 					}
 				}
 			}
 		},
-		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.46.tgz",
-			"integrity": "sha512-1QkKFWPsjrvMppycLwjPBXF+usSnGvbTxGe0Q+eIzcZyhabwGCsCgkmDIKMisPSAi6F7bM5H1S8VbE85IW3oRg==",
+		"@babel/plugin-transform-runtime": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+			"integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+				},
+				"resolve": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+					"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.46.tgz",
-			"integrity": "sha512-R0GvFdJnFrgTlmZfFtCXk81uvq5S3FuY38FnRsxDt6Yx/sE8jCmmrRe7XHZOnXXGP3ZWY9icILUmzWHOf91jbA==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.46.tgz",
-			"integrity": "sha512-2iGMsHWVAQq9X6p3VNjktJCH6ZXHQHi3NTPLKh5d4bEW8+M3H7LXLNqk1yUm/Uwt0tzh1FUfb/EU2sEPbrBrVA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
+			"integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "7.0.0-beta.46",
-				"@babel/helper-plugin-utils": "7.0.0-beta.46"
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz",
+			"integrity": "sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-typescript": "^7.2.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
+			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
 			}
 		},
 		"@babel/register": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.46.tgz",
-			"integrity": "sha512-S43PemtH5CSDE9GJesjUoAQGfC2rwLcc35gq/y6WQHPzWOd90yOvKydUk/pS7aSMrDiJSXYtyEeZFsq/8dtLhg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+			"integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
 			"requires": {
-				"core-js": "^2.5.3",
+				"core-js": "^2.5.7",
 				"find-cache-dir": "^1.0.0",
 				"home-or-tmp": "^3.0.0",
-				"lodash": "^4.2.0",
+				"lodash": "^4.17.10",
 				"mkdirp": "^0.5.1",
-				"pirates": "^3.0.1",
-				"source-map-support": "^0.4.2"
+				"pirates": "^4.0.0",
+				"source-map-support": "^0.5.9"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+					"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 				},
 				"home-or-tmp": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
 					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.5.10",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+			"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+			"requires": {
+				"regenerator-runtime": "^0.12.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 				}
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
-			"integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-					"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.46"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-					"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+				"@babel/parser": {
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+					"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
 				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
-			"integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.46",
-				"@babel/generator": "7.0.0-beta.46",
-				"@babel/helper-function-name": "7.0.0-beta.46",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
-				"@babel/types": "7.0.0-beta.46",
-				"babylon": "7.0.0-beta.46",
-				"debug": "^3.1.0",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"lodash": "^4.17.10"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-					"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.46"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-					"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
+				"@babel/parser": {
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+					"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
 				},
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"globals": {
-					"version": "11.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ=="
 				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.46",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
-			"integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+			"integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
+				"lodash": "^4.17.10",
 				"to-fast-properties": "^2.0.0"
 			},
 			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1341,15 +1498,10 @@
 				"default-require-extensions": "^1.0.0"
 			}
 		},
-		"arch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
-			"integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
-		},
 		"are-we-there-yet": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -1359,7 +1511,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1430,9 +1581,9 @@
 			"dev": true
 		},
 		"art": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/art/-/art-0.10.2.tgz",
-			"integrity": "sha512-0F3cb+pWScVwrbAi3b/GINGTZ4DKMcaKqzBIt57whlpkgCiJXA0vXR9fdlcvCnA/UzWJYSAFEslRXZQDypiW6A=="
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/art/-/art-0.10.3.tgz",
+			"integrity": "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ=="
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -1485,8 +1636,7 @@
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1525,6 +1675,7 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -1697,6 +1848,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -1706,16 +1858,6 @@
 				"lodash": "^4.17.4",
 				"source-map": "^0.5.7",
 				"trim-right": "^1.0.1"
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -1748,16 +1890,6 @@
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
 				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1799,28 +1931,6 @@
 				"babel-types": "^6.24.1"
 			}
 		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -1838,19 +1948,20 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
-			"version": "22.4.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
-			"integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.4.1"
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-preset-jest": "^23.2.0"
 			}
 		},
 		"babel-messages": {
@@ -1869,17 +1980,9 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
-		"babel-plugin-external-helpers": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
-			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
@@ -1901,9 +2004,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
-			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
 			"dev": true
 		},
 		"babel-plugin-module-resolver": {
@@ -1926,14 +2029,6 @@
 				}
 			}
 		},
-		"babel-plugin-react-transform": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
-			"integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
-			"requires": {
-				"lodash": "^4.6.1"
-			}
-		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -1947,12 +2042,8 @@
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
@@ -1974,16 +2065,6 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
 			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
-			"integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.16.0",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.0.0"
-			}
-		},
 		"babel-plugin-transform-class-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
@@ -1999,14 +2080,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2093,15 +2166,6 @@
 				"babel-types": "^6.26.0"
 			}
 		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
-			}
-		},
 		"babel-plugin-transform-es2015-parameters": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
@@ -2132,57 +2196,11 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
 		"babel-plugin-transform-es2015-template-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
-			}
-		},
-		"babel-plugin-transform-es3-member-expression-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
-			"integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es3-property-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
-			"integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
 				"babel-runtime": "^6.22.0"
 			}
 		},
@@ -2281,64 +2299,54 @@
 				}
 			}
 		},
-		"babel-preset-es2015-node": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-es2015-node/-/babel-preset-es2015-node-6.1.1.tgz",
-			"integrity": "sha1-YLIxVwJLDP6/OmNVTLBe4DW05V8=",
-			"requires": {
-				"babel-plugin-transform-es2015-destructuring": "6.x",
-				"babel-plugin-transform-es2015-function-name": "6.x",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.x",
-				"babel-plugin-transform-es2015-parameters": "6.x",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.x",
-				"babel-plugin-transform-es2015-spread": "6.x",
-				"babel-plugin-transform-es2015-sticky-regex": "6.x",
-				"babel-plugin-transform-es2015-unicode-regex": "6.x",
-				"semver": "5.x"
-			}
-		},
 		"babel-preset-fbjs": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
-			"integrity": "sha512-6XVQwlO26V5/0P9s2Eje8Epqkv/ihaMJ798+W98ktOA8fCn2IFM6wEi7CDW3fTbKFZ/8fDGvGZH01B6GSuNiWA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.1.2.tgz",
+			"integrity": "sha512-Bfrc4T3sub3TlXB19SQGKVigAiZpXJh05Cng8Iytn0TODXa86CigTkQnGun1FMQZJHrrpBpbm/IVDj+4K9lwAQ==",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.8.0",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-plugin-syntax-flow": "^6.8.0",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-				"babel-plugin-transform-class-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-				"babel-plugin-transform-es2015-classes": "^6.8.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.8.0",
-				"babel-plugin-transform-es2015-for-of": "^6.8.0",
-				"babel-plugin-transform-es2015-function-name": "^6.8.0",
-				"babel-plugin-transform-es2015-literals": "^6.8.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-				"babel-plugin-transform-es2015-object-super": "^6.8.0",
-				"babel-plugin-transform-es2015-parameters": "^6.8.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-spread": "^6.8.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.8.0",
-				"babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-				"babel-plugin-transform-es3-property-literals": "^6.8.0",
-				"babel-plugin-transform-flow-strip-types": "^6.8.0",
-				"babel-plugin-transform-object-rest-spread": "^6.8.0",
-				"babel-plugin-transform-react-display-name": "^6.8.0",
-				"babel-plugin-transform-react-jsx": "^6.8.0"
+				"@babel/plugin-proposal-class-properties": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-class-properties": "^7.0.0",
+				"@babel/plugin-syntax-flow": "^7.0.0",
+				"@babel/plugin-syntax-jsx": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-property-literals": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+			},
+			"dependencies": {
+				"babel-plugin-syntax-trailing-function-commas": {
+					"version": "7.0.0-beta.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+					"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+				}
 			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
-			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.4.4",
+				"babel-plugin-jest-hoist": "^23.2.0",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
@@ -2346,6 +2354,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
 			"integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.5.0",
 				"babel-plugin-react-transform": "^3.0.0",
@@ -2384,6 +2393,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
 					"integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
+					"dev": true,
 					"requires": {
 						"lodash": "^4.6.1"
 					}
@@ -2394,6 +2404,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -2407,7 +2418,8 @@
 				"core-js": {
 					"version": "2.5.3",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-					"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+					"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+					"dev": true
 				}
 			}
 		},
@@ -2516,11 +2528,18 @@
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"basic-auth": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-			"integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"bcrypt-pbkdf": {
@@ -2533,9 +2552,9 @@
 			}
 		},
 		"big-integer": {
-			"version": "1.6.28",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.28.tgz",
-			"integrity": "sha512-OJT3rzgtsYca/5WmmEuFJDPMwROVh5SSjoEX9wIrpfbbWJ4KqRzShs8Cj6jWHaatBYAeWngBA+kmmrcHSklT1g=="
+			"version": "1.6.40",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
+			"integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ=="
 		},
 		"bplist-creator": {
 			"version": "0.0.7",
@@ -2641,6 +2660,14 @@
 				}
 			}
 		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"requires": {
+				"callsites": "^2.0.0"
+			}
+		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2661,14 +2688,12 @@
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-			"dev": true
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-			"dev": true
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -2795,15 +2820,6 @@
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
-		"clipboardy": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-			"integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-			"requires": {
-				"arch": "^2.1.0",
-				"execa": "^0.8.0"
-			}
-		},
 		"cliui": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -2885,9 +2901,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -2900,25 +2916,39 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
-			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
 			"requires": {
-				"mime-db": ">= 1.33.0 < 2"
+				"mime-db": ">= 1.36.0 < 2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.37.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+					"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+				}
 			}
 		},
 		"compression": {
-			"version": "1.7.2",
-			"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
 			"requires": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "~2.0.13",
+				"compressible": "~2.0.14",
 				"debug": "2.6.9",
 				"on-headers": "~1.0.1",
-				"safe-buffer": "5.1.1",
+				"safe-buffer": "5.1.2",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"concat-map": {
@@ -2967,6 +2997,28 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cosmiconfig": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+			"requires": {
+				"import-fresh": "^2.0.0",
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.9.0",
+				"parse-json": "^4.0.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				}
+			}
 		},
 		"create-react-class": {
 			"version": "15.6.3",
@@ -3124,6 +3176,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -3196,16 +3249,9 @@
 			}
 		},
 		"envinfo": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.11.1.tgz",
-			"integrity": "sha512-hKkh7aKtont6Zuv4RmE4VkOc96TkBj9NXj7Ghsd/qCA9LuJI0Dh+ImwA1N5iORB9Vg+sz5bq9CHJzs51BILNCQ==",
-			"requires": {
-				"clipboardy": "^1.2.2",
-				"glob": "^7.1.2",
-				"minimist": "^1.2.0",
-				"os-name": "^2.0.1",
-				"which": "^1.2.14"
-			}
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.12.1.tgz",
+			"integrity": "sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w=="
 		},
 		"error-ex": {
 			"version": "1.3.1",
@@ -3498,19 +3544,6 @@
 				}
 			}
 		},
-		"eslint-plugin-react-native": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-3.2.1.tgz",
-			"integrity": "sha512-1AnJO3JUCAoLpyOEsWCwN9hPJ0aQ72OT+JvLMuHjEWYb6QWxiNOszp24CEwegMzbREtJKI9OoRqYYDYxMxmjgQ==",
-			"requires": {
-				"eslint-plugin-react-native-globals": "^0.1.1"
-			}
-		},
-		"eslint-plugin-react-native-globals": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz",
-			"integrity": "sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g=="
-		},
 		"eslint-scope": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
@@ -3555,8 +3588,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.0.1",
@@ -3598,9 +3630,9 @@
 			"integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
 		},
 		"eventemitter3": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
-			"integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
 		},
 		"exec-sh": {
 			"version": "0.2.1",
@@ -3608,20 +3640,6 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"requires": {
 				"merge": "^1.1.3"
-			}
-		},
-		"execa": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -3721,12 +3739,13 @@
 			"dev": true
 		},
 		"fancy-log": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+			"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
 			"requires": {
 				"ansi-gray": "^0.1.1",
 				"color-support": "^1.1.3",
+				"parse-node-version": "^1.0.0",
 				"time-stamp": "^1.0.0"
 			}
 		},
@@ -3778,14 +3797,19 @@
 				"ua-parser-js": "^0.7.9"
 			}
 		},
+		"fbjs-css-vars": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
+		},
 		"fbjs-scripts": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz",
-			"integrity": "sha512-aUJ/uEzMIiBYuj/blLp4sVNkQQ7ZEB/lyplG1IzzOmZ83meiWecrGg5jBo4wWrxXmO4RExdtsSV1QkTjPt2Gag==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-1.0.1.tgz",
+			"integrity": "sha512-x8bfX7k0z5B24Ue0YqjZq/2QxxaKZUNbkGdX//zbQDElMJFqBRrvRi8O3qds7UNNzs78jYqIYCS32Sk/wu5UJg==",
 			"requires": {
+				"@babel/core": "^7.0.0",
 				"ansi-colors": "^1.0.1",
-				"babel-core": "^6.7.2",
-				"babel-preset-fbjs": "^2.1.2",
+				"babel-preset-fbjs": "^3.0.0",
 				"core-js": "^2.4.1",
 				"cross-spawn": "^5.1.0",
 				"fancy-log": "^1.3.2",
@@ -3796,9 +3820,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+					"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 				}
 			}
 		},
@@ -4064,6 +4088,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"inherits": "~2.0.0"
 					}
@@ -4085,7 +4110,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -4099,7 +4125,8 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
@@ -4115,15 +4142,18 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"boom": "2.x.x"
 					}
@@ -4186,7 +4216,8 @@
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
@@ -4295,6 +4326,7 @@
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"boom": "2.x.x",
 						"cryptiles": "2.x.x",
@@ -4336,6 +4368,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4347,7 +4380,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -4534,7 +4568,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -4567,6 +4602,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -4615,7 +4651,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"semver": {
 					"version": "5.3.0",
@@ -4635,6 +4672,7 @@
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"hoek": "2.x.x"
 					}
@@ -4665,6 +4703,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4674,6 +4713,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -4698,6 +4738,7 @@
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"block-stream": "*",
 						"fstream": "^1.0.2",
@@ -4747,7 +4788,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",
@@ -5421,6 +5463,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -5486,9 +5529,28 @@
 			"dev": true
 		},
 		"image-size": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.2.tgz",
-			"integrity": "sha512-pH3vDzpczdsKHdZ9xxR3O46unSjisgVx0IImay7Zz2EdhRVbCkj+nthx9OuuWEhakx9FAO+fNVGrF0rZ2oMOvw=="
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
+			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"requires": {
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"caller-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+					"requires": {
+						"caller-callsite": "^2.0.0"
+					}
+				}
+			}
 		},
 		"import-local": {
 			"version": "1.0.0",
@@ -5554,9 +5616,9 @@
 					}
 				},
 				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -5572,9 +5634,9 @@
 					}
 				},
 				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -5680,6 +5742,11 @@
 				}
 			}
 		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -5707,6 +5774,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -6384,9 +6452,9 @@
 			}
 		},
 		"jest-docblock": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
-			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
@@ -6476,15 +6544,16 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
-			"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+			"version": "23.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.5.0.tgz",
+			"integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^22.4.0",
-				"jest-serializer": "^22.4.0",
-				"jest-worker": "^22.2.2",
+				"invariant": "^2.2.4",
+				"jest-docblock": "^23.2.0",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.2.0",
 				"micromatch": "^2.3.11",
 				"sane": "^2.0.0"
 			}
@@ -7005,9 +7074,9 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw=="
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
 		},
 		"jest-snapshot": {
 			"version": "23.6.0",
@@ -7229,9 +7298,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
 			"requires": {
 				"merge-stream": "^1.0.1"
 			}
@@ -7245,7 +7314,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -7317,7 +7385,13 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -7420,11 +7494,6 @@
 				"invert-kv": "^1.0.0"
 			}
 		},
-		"left-pad": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
-		},
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -7523,15 +7592,10 @@
 				"yallist": "^2.1.2"
 			}
 		},
-		"macos-release": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
-		},
 		"make-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
 				"pify": "^3.0.0"
 			},
@@ -7615,82 +7679,48 @@
 			}
 		},
 		"metro": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro/-/metro-0.30.2.tgz",
-			"integrity": "sha512-wmdkh4AsfZjWaMM++KMDswQHdyo5L9a0XAaQBL4XTJdQIRG+x+Rmjixe7tDki5jKwe9XxsjjbpbdYKswOANuiw==",
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro/-/metro-0.48.5.tgz",
+			"integrity": "sha512-aCarzjxdYqh+9I40bF+Hh1ayrwfPrnDwVOvpQg3VZFWU4wfeMiJb+tzeRN9p94cC/MKhBTOjRmUF3plzrHoe0w==",
 			"requires": {
-				"@babel/core": "^7.0.0-beta",
-				"@babel/generator": "^7.0.0-beta",
-				"@babel/helper-remap-async-to-generator": "^7.0.0-beta",
-				"@babel/plugin-external-helpers": "^7.0.0-beta",
-				"@babel/plugin-proposal-class-properties": "^7.0.0-beta",
-				"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta",
-				"@babel/plugin-syntax-dynamic-import": "^7.0.0-beta",
-				"@babel/plugin-transform-arrow-functions": "^7.0.0-beta",
-				"@babel/plugin-transform-block-scoping": "^7.0.0-beta",
-				"@babel/plugin-transform-classes": "^7.0.0-beta",
-				"@babel/plugin-transform-computed-properties": "^7.0.0-beta",
-				"@babel/plugin-transform-destructuring": "^7.0.0-beta",
-				"@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0-beta",
-				"@babel/plugin-transform-for-of": "^7.0.0-beta",
-				"@babel/plugin-transform-function-name": "^7.0.0-beta",
-				"@babel/plugin-transform-literals": "^7.0.0-beta",
-				"@babel/plugin-transform-modules-commonjs": "^7.0.0-beta",
-				"@babel/plugin-transform-object-assign": "^7.0.0-beta",
-				"@babel/plugin-transform-parameters": "^7.0.0-beta",
-				"@babel/plugin-transform-react-display-name": "^7.0.0-beta",
-				"@babel/plugin-transform-react-jsx": "^7.0.0-beta",
-				"@babel/plugin-transform-react-jsx-source": "^7.0.0-beta",
-				"@babel/plugin-transform-regenerator": "^7.0.0-beta",
-				"@babel/plugin-transform-shorthand-properties": "^7.0.0-beta",
-				"@babel/plugin-transform-spread": "^7.0.0-beta",
-				"@babel/plugin-transform-template-literals": "^7.0.0-beta",
-				"@babel/register": "^7.0.0-beta",
-				"@babel/template": "^7.0.0-beta",
-				"@babel/traverse": "^7.0.0-beta",
-				"@babel/types": "^7.0.0-beta",
+				"@babel/core": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/plugin-external-helpers": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"absolute-path": "^0.0.0",
 				"async": "^2.4.0",
-				"babel-core": "^6.24.1",
-				"babel-generator": "^6.26.0",
-				"babel-plugin-external-helpers": "^6.22.0",
-				"babel-plugin-react-transform": "^3.0.0",
-				"babel-plugin-transform-flow-strip-types": "^6.21.0",
-				"babel-preset-es2015-node": "^6.1.1",
-				"babel-preset-fbjs": "^2.1.4",
-				"babel-preset-react-native": "^4.0.0",
-				"babel-register": "^6.24.1",
-				"babel-template": "^6.24.1",
-				"babylon": "^6.18.0",
+				"babel-preset-fbjs": "^3.0.1",
 				"chalk": "^1.1.1",
 				"concat-stream": "^1.6.0",
 				"connect": "^3.6.5",
-				"core-js": "^2.2.2",
 				"debug": "^2.2.0",
 				"denodeify": "^1.2.1",
 				"eventemitter3": "^3.0.0",
-				"fbjs": "^0.8.14",
+				"fbjs": "^1.0.0",
 				"fs-extra": "^1.0.0",
 				"graceful-fs": "^4.1.3",
 				"image-size": "^0.6.0",
-				"jest-docblock": "22.4.0",
-				"jest-haste-map": "22.4.2",
-				"jest-worker": "22.2.2",
+				"jest-docblock": "23.2.0",
+				"jest-haste-map": "23.5.0",
+				"jest-worker": "23.2.0",
 				"json-stable-stringify": "^1.0.1",
-				"json5": "^0.4.0",
-				"left-pad": "^1.1.3",
 				"lodash.throttle": "^4.1.1",
 				"merge-stream": "^1.0.1",
-				"metro-babylon7": "0.30.2",
-				"metro-cache": "0.30.2",
-				"metro-core": "0.30.2",
-				"metro-minify-uglify": "0.30.2",
-				"metro-resolver": "0.30.2",
-				"metro-source-map": "0.30.2",
+				"metro-cache": "0.48.5",
+				"metro-config": "0.48.5",
+				"metro-core": "0.48.5",
+				"metro-minify-uglify": "0.48.5",
+				"metro-react-native-babel-preset": "0.48.5",
+				"metro-resolver": "0.48.5",
+				"metro-source-map": "0.48.5",
 				"mime-types": "2.1.11",
 				"mkdirp": "^0.5.1",
-				"node-fetch": "^1.3.3",
+				"node-fetch": "^2.2.0",
+				"nullthrows": "^1.1.0",
+				"react-transform-hmr": "^1.0.4",
 				"resolve": "^1.5.0",
 				"rimraf": "^2.5.4",
 				"serialize-error": "^2.1.0",
@@ -7705,22 +7735,66 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+					"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 				},
-				"jest-worker": {
-					"version": "22.2.2",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
-					"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+				"fbjs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+					"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
 					"requires": {
-						"merge-stream": "^1.0.1"
+						"core-js": "^2.4.1",
+						"fbjs-css-vars": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.18"
 					}
 				},
-				"json5": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+				"metro-react-native-babel-preset": {
+					"version": "0.48.5",
+					"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.48.5.tgz",
+					"integrity": "sha512-ldG1bsusB5zlS1fhAiSLRjUA7I/Chn/dniaXTlkUpgiqyEAaDDmqhkDJ8gyZw3rhlLMVswlBd3o6I8yYti+57w==",
+					"requires": {
+						"@babel/plugin-proposal-class-properties": "^7.0.0",
+						"@babel/plugin-proposal-export-default-from": "^7.0.0",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+						"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+						"@babel/plugin-syntax-export-default-from": "^7.0.0",
+						"@babel/plugin-transform-arrow-functions": "^7.0.0",
+						"@babel/plugin-transform-block-scoping": "^7.0.0",
+						"@babel/plugin-transform-classes": "^7.0.0",
+						"@babel/plugin-transform-computed-properties": "^7.0.0",
+						"@babel/plugin-transform-destructuring": "^7.0.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+						"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+						"@babel/plugin-transform-for-of": "^7.0.0",
+						"@babel/plugin-transform-function-name": "^7.0.0",
+						"@babel/plugin-transform-literals": "^7.0.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+						"@babel/plugin-transform-object-assign": "^7.0.0",
+						"@babel/plugin-transform-parameters": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.0.0",
+						"@babel/plugin-transform-react-jsx": "^7.0.0",
+						"@babel/plugin-transform-react-jsx-source": "^7.0.0",
+						"@babel/plugin-transform-regenerator": "^7.0.0",
+						"@babel/plugin-transform-runtime": "^7.0.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+						"@babel/plugin-transform-spread": "^7.0.0",
+						"@babel/plugin-transform-sticky-regex": "^7.0.0",
+						"@babel/plugin-transform-template-literals": "^7.0.0",
+						"@babel/plugin-transform-typescript": "^7.0.0",
+						"@babel/plugin-transform-unicode-regex": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"metro-babel7-plugin-react-transform": "0.48.5",
+						"react-transform-hmr": "^1.0.4"
+					}
 				},
 				"mime-db": {
 					"version": "1.23.0",
@@ -7735,13 +7809,28 @@
 						"mime-db": "~1.23.0"
 					}
 				},
+				"node-fetch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+				},
 				"resolve": {
-					"version": "1.7.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+					"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "^1.0.6"
 					}
+				},
+				"ua-parser-js": {
+					"version": "0.7.19",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+					"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 				},
 				"wordwrap": {
 					"version": "1.0.0",
@@ -7750,36 +7839,95 @@
 				}
 			}
 		},
-		"metro-babylon7": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-babylon7/-/metro-babylon7-0.30.2.tgz",
-			"integrity": "sha512-ZI0h4/3raGnzA6fFXwLUMidGOG4jkDi9fgFkoI8I4Ack3TDMabmZATu9RD6DaSolu3lylhfPd8DeAAMeopX9CA==",
+		"metro-babel-register": {
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-babel-register/-/metro-babel-register-0.48.5.tgz",
+			"integrity": "sha512-bJCessd7THqEfXrKEoj284XVjg9AGYbGqZiyV622l6ex9TvtVi1lToDY0TuAAuDXOm+V4vQXV7/HvR6JPP0dTQ==",
 			"requires": {
-				"babylon": "^7.0.0-beta"
+				"@babel/core": "^7.0.0",
+				"@babel/plugin-proposal-class-properties": "^7.0.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+				"@babel/plugin-transform-async-to-generator": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/register": "^7.0.0",
+				"core-js": "^2.2.2",
+				"escape-string-regexp": "^1.0.5"
 			},
 			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+				"core-js": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+					"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 				}
 			}
 		},
-		"metro-cache": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.30.2.tgz",
-			"integrity": "sha512-XYd07OwgtZRHFXyip40wdNJ8abPJRziuE5bb3jjf8wvyHxCpzlZlvbe0ZhcR8ChBwFUjHMuVyoou52AC3a0f+g==",
+		"metro-babel7-plugin-react-transform": {
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.48.5.tgz",
+			"integrity": "sha512-S0cA0msHBGw7PSwB6nAsvtHEpQXVwzKBaE4AibLpaBiIVdWkYpIOok653zs9x+E9QvQgcghAnlVnDV+MDM+rSw==",
 			"requires": {
-				"jest-serializer": "^22.4.0",
-				"mkdirp": "^0.5.1"
+				"@babel/helper-module-imports": "^7.0.0"
+			}
+		},
+		"metro-cache": {
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.48.5.tgz",
+			"integrity": "sha512-vlUf3A6+U3LXcf6wAn42N22q1h7MMoopA25w5KR4Flwd0xKVokxHwsTo9v06vpn4gqFtpXWCpEJSBaYRrWYJwg==",
+			"requires": {
+				"jest-serializer": "23.0.1",
+				"metro-core": "0.48.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4"
+			}
+		},
+		"metro-config": {
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.48.5.tgz",
+			"integrity": "sha512-b+EmFgBOAEUM5THjJ2EU6CJxnULLC5V1Q8S8dz4xX4v96eLIsRCLPrXgYKATHJTVi0qw99ATVRsOBZVZ77fwjg==",
+			"requires": {
+				"cosmiconfig": "^5.0.5",
+				"metro": "0.48.5",
+				"metro-cache": "0.48.5",
+				"metro-core": "0.48.5",
+				"pretty-format": "^23.4.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				}
 			}
 		},
 		"metro-core": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.30.2.tgz",
-			"integrity": "sha512-2Y89PpD9sE/8QaHhYxaI21WFxkVmjbxdphiOPdsC9t7A3kQHMYOTQPYFon3bkYM7tL8k9YVBimXSv20JGglqUA==",
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.48.5.tgz",
+			"integrity": "sha512-Yp0BOAHhxf/qdNkwJhemVdD2Y59iyaTjwxUimCmeD8u5VEL6mLgEC1S0KczyWEiAgX3Fs48rezCAcx3mo67wXg==",
 			"requires": {
+				"jest-haste-map": "23.5.0",
 				"lodash.throttle": "^4.1.1",
+				"metro-resolver": "0.48.5",
 				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
@@ -7790,47 +7938,85 @@
 				}
 			}
 		},
+		"metro-memory-fs": {
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-memory-fs/-/metro-memory-fs-0.48.5.tgz",
+			"integrity": "sha512-dxN0dBtMOR1CvyRIOM/NE+uFirybWb4y2PZke0Z8bpYn6ttmv8ZF3PVdFxJf9v9irVBSOIPD0mD5zllxQkXzhg=="
+		},
 		"metro-minify-uglify": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.30.2.tgz",
-			"integrity": "sha512-xwqMqYYKZEqJ66Wpf5OpyPJhApOQDb8rYiO94VInlDeHpN7eKGCVILclnx9AmVM3dStmebvXa5jrdgsbnJ1bSg==",
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.48.5.tgz",
+			"integrity": "sha512-tiHVYlUMuL91YjQPx9BzzzXy5jAAA5SWLqlvWfmM6m9faWtFeCv8Se27vVNuPDkOPYyL8qPCRhUpZMUhA0yN2g==",
 			"requires": {
 				"uglify-es": "^3.1.9"
+			}
+		},
+		"metro-react-native-babel-preset": {
+			"version": "0.51.1",
+			"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.51.1.tgz",
+			"integrity": "sha512-e9tsYDFhU70gar0jQWcZXRPJVCv4k7tEs6Pm74wXO2OO/T1MEumbvniDIGwGG8bG8RUnYdHhjcaiub2Vc5BRWw==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-proposal-class-properties": "^7.0.0",
+				"@babel/plugin-proposal-export-default-from": "^7.0.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-proposal-optional-chaining": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+				"@babel/plugin-syntax-export-default-from": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/plugin-transform-object-assign": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-react-display-name": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.0.0",
+				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-runtime": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-sticky-regex": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"@babel/plugin-transform-typescript": "^7.0.0",
+				"@babel/plugin-transform-unicode-regex": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"metro-babel7-plugin-react-transform": "0.51.1",
+				"react-transform-hmr": "^1.0.4"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+				"metro-babel7-plugin-react-transform": {
+					"version": "0.51.1",
+					"resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.51.1.tgz",
+					"integrity": "sha512-wzn4X9KgmAMZ7Bi6v9KxA7dw+AHGL0RODPxU5NDJ3A6d0yERvzfZ3qkzWhz8jbFkVBK12cu5DTho3HBazKQDOw==",
+					"dev": true,
 					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
+						"@babel/helper-module-imports": "^7.0.0"
 					}
 				}
 			}
 		},
 		"metro-resolver": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.30.2.tgz",
-			"integrity": "sha512-bODCys/WYpqJ+KYbCIENZu1eqdQu3g/d2fXfhAROhutqojMqrT1eIGhzWpk3G1k/J6vlaf69uW6xrVuheg0ktg==",
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.48.5.tgz",
+			"integrity": "sha512-lScSpLJKZMmNPRwvcY6zj28AwMOcI1M5bCCv+m06VWcISCTq1KlaKVwqLKmFgUtPkoFtFLD+PVKRKCRUxj1opg==",
 			"requires": {
 				"absolute-path": "^0.0.0"
 			}
 		},
 		"metro-source-map": {
-			"version": "0.30.2",
-			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.30.2.tgz",
-			"integrity": "sha512-9tW3B1JOdXhyDJnR4wOPOsOlYWSL+xh6J+N5/DADGEK/X/+Up/lEHdEfpB+/+yGk1LHaRHcKCahtLPNl/to7Sg==",
+			"version": "0.48.5",
+			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.48.5.tgz",
+			"integrity": "sha512-+BbcU9vfEl/XhMlVV0RwuHuEkai4lq7RmlQkxgoOoWl1u0yXCAPRZ5sqa326fPlJzElOR3cp0y7+Oc2nbIguyg==",
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -7934,13 +8120,13 @@
 			}
 		},
 		"morgan": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
-			"integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+			"integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
 			"requires": {
 				"basic-auth": "~2.0.0",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
+				"depd": "~1.1.2",
 				"on-finished": "~2.3.0",
 				"on-headers": "~1.0.1"
 			}
@@ -11935,6 +12121,11 @@
 				"gauge": "~1.2.5"
 			}
 		},
+		"nullthrows": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -12231,7 +12422,8 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "2.1.0",
@@ -12257,15 +12449,6 @@
 						"strip-eof": "^1.0.0"
 					}
 				}
-			}
-		},
-		"os-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
-			"requires": {
-				"macos-release": "^1.0.0",
-				"win-release": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -12317,6 +12500,11 @@
 			"requires": {
 				"error-ex": "^1.2.0"
 			}
+		},
+		"parse-node-version": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
+			"integrity": "sha512-02GTVHD1u0nWc20n2G7WX/PgdhNFG04j5fi1OkaJzPWLTcf6vh6229Lta1wTmXG/7Dg42tCssgkccVt7qvd8Kg=="
 		},
 		"parse5": {
 			"version": "4.0.0",
@@ -12375,11 +12563,6 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
-		"pegjs": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -12405,9 +12588,9 @@
 			}
 		},
 		"pirates": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
-			"integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+			"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
 			}
@@ -12431,21 +12614,13 @@
 			}
 		},
 		"plist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-			"integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
 			"requires": {
-				"base64-js": "0.0.8",
-				"util-deprecate": "1.0.2",
-				"xmlbuilder": "4.0.0",
+				"base64-js": "^1.2.3",
+				"xmlbuilder": "^9.0.7",
 				"xmldom": "0.1.x"
-			},
-			"dependencies": {
-				"base64-js": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-					"integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-				}
 			}
 		},
 		"plugin-error": {
@@ -12720,20 +12895,31 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"react": {
-			"version": "16.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
-			"integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.6.1.tgz",
+			"integrity": "sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==",
 			"requires": {
-				"fbjs": "^0.8.16",
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.11.0"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"react-clone-referenced-element": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz",
-			"integrity": "sha1-K7qMaUBMXkqUQ5hgC8xMlB+GBoI="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
+			"integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
 		},
 		"react-deep-force-update": {
 			"version": "1.1.1",
@@ -12741,51 +12927,45 @@
 			"integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw="
 		},
 		"react-devtools-core": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.1.0.tgz",
-			"integrity": "sha512-fO6SmpW16E9u6Lb6zQOHrjhJXGBNz+cJ0/a9cSF55nXfL0sQLlvYJR8DpU7f4rMUrVnVineg4XQyYYBZicmhJg==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.5.3.tgz",
+			"integrity": "sha512-0/0OGEjchZNgKzahGi6TqHfMEc9J6VMYl6NXCawZB5levXEwh9Svij+iaIMP1LvgEfOzA8tF6jnvYzzvQh61zg==",
 			"requires": {
 				"shell-quote": "^1.6.1",
-				"ws": "^2.0.3"
+				"ws": "^3.3.1"
 			},
 			"dependencies": {
-				"safe-buffer": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-				},
 				"ultron": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
 					"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 				},
 				"ws": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-					"integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 					"requires": {
-						"safe-buffer": "~5.0.1",
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
 						"ultron": "~1.1.0"
 					}
 				}
 			}
 		},
+		"react-is": {
+			"version": "16.7.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+			"integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
+			"dev": true
+		},
 		"react-native": {
-			"version": "0.55.1",
-			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.55.1.tgz",
-			"integrity": "sha512-hZV1UsRMA9awMrKYqbutuYvy6qeebwS/+QnmRJ+pLSxVG+yKOpzzpsNyzFxqkp3dNY9evdIVTRDoeItGMGmVJw==",
+			"version": "0.57.7",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.57.7.tgz",
+			"integrity": "sha512-mdNibV6NblH8gbbcWjLjH6lVOkrXuCiIi+RQ+6e2QlrOIJVsKC216VvBhHsvdDIRO94v1qD8LMnTYlBY09qzQQ==",
 			"requires": {
+				"@babel/runtime": "^7.0.0",
 				"absolute-path": "^0.0.0",
 				"art": "^0.10.0",
-				"babel-core": "^6.24.1",
-				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-				"babel-plugin-transform-async-to-generator": "6.16.0",
-				"babel-plugin-transform-class-properties": "^6.18.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.5.0",
-				"babel-plugin-transform-flow-strip-types": "^6.21.0",
-				"babel-plugin-transform-object-rest-spread": "^6.20.2",
-				"babel-register": "^6.24.1",
-				"babel-runtime": "^6.23.0",
 				"base64-js": "^1.1.2",
 				"chalk": "^1.1.1",
 				"commander": "^2.9.0",
@@ -12794,34 +12974,36 @@
 				"create-react-class": "^15.6.3",
 				"debug": "^2.2.0",
 				"denodeify": "^1.2.1",
-				"envinfo": "^3.0.0",
+				"envinfo": "^5.7.0",
 				"errorhandler": "^1.5.0",
-				"eslint-plugin-react-native": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
 				"event-target-shim": "^1.0.5",
-				"fbjs": "^0.8.14",
-				"fbjs-scripts": "^0.8.1",
+				"fbjs": "^1.0.0",
+				"fbjs-scripts": "^1.0.0",
 				"fs-extra": "^1.0.0",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.1.3",
 				"inquirer": "^3.0.6",
 				"lodash": "^4.17.5",
-				"metro": "^0.30.0",
-				"metro-core": "^0.30.0",
+				"metro": "^0.48.1",
+				"metro-babel-register": "^0.48.1",
+				"metro-core": "^0.48.1",
+				"metro-memory-fs": "^0.48.1",
 				"mime": "^1.3.4",
 				"minimist": "^1.2.0",
 				"mkdirp": "^0.5.1",
 				"morgan": "^1.9.0",
-				"node-fetch": "^1.3.3",
+				"node-fetch": "^2.2.0",
 				"node-notifier": "^5.2.1",
 				"npmlog": "^2.0.4",
 				"opn": "^3.0.2",
 				"optimist": "^0.6.1",
-				"plist": "^1.2.0",
+				"plist": "^3.0.0",
 				"pretty-format": "^4.2.1",
 				"promise": "^7.1.1",
 				"prop-types": "^15.5.8",
 				"react-clone-referenced-element": "^1.0.1",
-				"react-devtools-core": "3.1.0",
+				"react-devtools-core": "^3.4.2",
 				"react-timer-mixin": "^0.13.2",
 				"regenerator-runtime": "^0.11.0",
 				"rimraf": "^2.5.4",
@@ -12829,22 +13011,41 @@
 				"serve-static": "^1.13.1",
 				"shell-quote": "1.6.1",
 				"stacktrace-parser": "^0.1.3",
-				"whatwg-fetch": "^1.0.0",
 				"ws": "^1.1.0",
-				"xcode": "^0.9.1",
+				"xcode": "^1.0.0",
 				"xmldoc": "^0.4.0",
 				"yargs": "^9.0.0"
 			},
 			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				"core-js": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+					"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
 				},
-				"whatwg-fetch": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz",
-					"integrity": "sha1-rDydOfMgxtzlM5lp0FTvQ90zMxk="
+				"fbjs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+					"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+					"requires": {
+						"core-js": "^2.4.1",
+						"fbjs-css-vars": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.18"
+					}
+				},
+				"node-fetch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+				},
+				"ua-parser-js": {
+					"version": "0.7.19",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+					"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 				}
 			}
 		},
@@ -12942,19 +13143,33 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.0.0-beta.5",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0-beta.5.tgz",
-			"integrity": "sha512-cTgpGjbew12c6MZqTe4qjWE91GxRrl9nRHYJKLayPSu10E4ZeMr/xOVy4fkY78dKwgSJVu/6oYIoN84leh81XA==",
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.1.tgz",
+			"integrity": "sha512-sgZwJZYIgQptRi2qk5+gB8FBQGk4gLSs0gmKZPMfhd3dLkdxIUwVLHteLN3Bnj4LokIZd3U+V2NEJUqeV2PT2w==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.9",
-				"object-assign": "^4.1.0"
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.6.1",
+				"scheduler": "^0.11.0"
+			},
+			"dependencies": {
+				"prop-types": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"react-timer-mixin": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz",
-			"integrity": "sha1-Dai5+AfsB9w+hU0ILHN8ZWBbPSI="
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
+			"integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
 		},
 		"react-transform-hmr": {
 			"version": "1.0.4",
@@ -12966,9 +13181,9 @@
 			}
 		},
 		"react-viro": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/react-viro/-/react-viro-2.8.1.tgz",
-			"integrity": "sha1-e22k8QCzQRITj2+KjWiaSqB+oJY=",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/react-viro/-/react-viro-2.13.0.tgz",
+			"integrity": "sha512-CTc41zMGLJ26+uAaLwPIepBNM/kQ/pEV8bNCklXX8ofY4UQDWn+g6NgNcdEa3r1jOVMOlj33ojDgY3Ifblm3IQ==",
 			"requires": {
 				"prop-types": "^15.5.10"
 			}
@@ -13018,9 +13233,22 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -13056,24 +13284,27 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
+			"integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^7.0.0",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.0.2"
 			}
 		},
 		"regjsgen": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
 		},
 		"regjsparser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -13104,6 +13335,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -13241,8 +13473,7 @@
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-			"dev": true
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -13579,6 +13810,15 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
 			"integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
 		},
+		"scheduler": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.3.tgz",
+			"integrity": "sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==",
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -13743,7 +13983,8 @@
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "2.0.0",
@@ -13910,6 +14151,7 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -13958,8 +14200,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.15.2",
@@ -14530,11 +14771,11 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"requires": {
-				"readable-stream": "^2.1.5",
+				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
 		},
@@ -14662,6 +14903,27 @@
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
 			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
 		},
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+			"requires": {
+				"commander": "~2.13.0",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -14693,6 +14955,30 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
 			"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -14829,8 +15115,7 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
@@ -14958,14 +15243,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
-		"win-release": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-			"requires": {
-				"semver": "^5.0.1"
-			}
-		},
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
@@ -15034,20 +15311,12 @@
 			}
 		},
 		"xcode": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
-			"integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-1.1.0.tgz",
+			"integrity": "sha512-hllHFtfsNu5WbVzj8KbGNdI3NgOYmTLZqyF4a9c9J1aGMhAdxmLLsXlpG0Bz8fEtKh6I3pyargRXN0ZlLpcF5w==",
 			"requires": {
-				"pegjs": "^0.10.0",
 				"simple-plist": "^0.2.1",
-				"uuid": "3.0.1"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-				}
+				"uuid": "^3.3.2"
 			}
 		},
 		"xml-name-validator": {
@@ -15057,19 +15326,9 @@
 			"dev": true
 		},
 		"xmlbuilder": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-			"integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
-			"requires": {
-				"lodash": "^3.5.0"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-				}
-			}
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xmldoc": {
 			"version": "0.4.0",
@@ -15129,11 +15388,6 @@
 				"yargs-parser": "^7.0.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -15223,13 +15477,6 @@
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 			"requires": {
 				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -12,25 +12,26 @@
     "@zsajjad/react-native-heading": "https://github.com/zsajjad/react-native-heading.git",
     "firebase": "^5.3.0",
     "npm": "^5.8.0",
-    "react": "16.3.1",
-    "react-native": "0.55.1",
+    "react": "16.6.1",
+    "react-native": "0.57.7",
     "react-native-firebase": "^4.3.7",
     "react-native-geojson": "^0.1.1",
     "react-native-maps": "^0.21.0",
     "react-native-modal-filter-picker": "https://github.com/parideis/react-native-modal-filter-picker.git",
-    "react-viro": "2.8.1",
+    "react-viro": "2.13.0",
     "tcomb-form-native": "^0.6.15"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",
-    "babel-jest": "22.4.1",
+    "babel-jest": "23.6.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react-native": "4.0.0",
     "eslint": "^5.9.0",
     "eslint-plugin-react": "^7.11.1",
     "jest": "23.6.0",
-    "react-test-renderer": "16.0.0-beta.5"
+    "metro-react-native-babel-preset": "0.51.1",
+    "react-test-renderer": "16.6.1"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@zsajjad/react-native-heading": "https://github.com/zsajjad/react-native-heading.git",
     "firebase": "^5.3.0",
     "npm": "^5.8.0",
     "react": "16.6.1",
     "react-native": "0.57.7",
     "react-native-firebase": "^4.3.7",
     "react-native-geojson": "^0.1.1",
+    "react-native-heading": "^1.1.1",
     "react-native-maps": "^0.21.0",
     "react-native-modal-filter-picker": "https://github.com/parideis/react-native-modal-filter-picker.git",
     "react-viro": "2.13.0",


### PR DESCRIPTION
This update made the build fail while using `@zsajjad/react-native-heading`, so I switched to `@yonahforst/react-native-heading`. It still isn't included correctly, but at least the build doesn't fail.